### PR TITLE
bugfix: page loading indefinitely because of changes in the api

### DIFF
--- a/src/lib/components/ui/ModIcon.svelte
+++ b/src/lib/components/ui/ModIcon.svelte
@@ -7,8 +7,16 @@
 	let imgSrc = `/modicons/${mod}.webp`;
 	let modName = playUtils.convertAliasToLongModName(mod);
 
+	const supportedMods = [
+		'AP', 'AT', 'CM', 'DT', 'EZ',
+		'FL', 'HD', 'HF', 'HR', 'HT',
+		'NC', 'NF', 'PF', 'PR', 'RX',
+		'SD', 'SO', 'TD', 'TP', 'NM',
+		'None'
+	];
+
 	function shouldDisplayModIcon(mod: string): boolean {
-		return !(mod === 'NM' || mod === 'None' || mod.startsWith('x'));
+		return supportedMods.includes(mod) && !mod.startsWith('x');
 	}
 </script>
 


### PR DESCRIPTION
The api used to send an array of string for Mods:
`['HD', 'DT']`.

Now it send an array of object with acronym and possible settings: 
`[{ acronym: "CS", settings: { rateMultiplier: 1.50 }}, { acronym: "PR"}]`

So this caused the page to load indefinitely because of the display of mods not working.